### PR TITLE
Add unit declarator to module and class declarations

### DIFF
--- a/lib/FastCGI.pm6
+++ b/lib/FastCGI.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class FastCGI;
+unit class FastCGI;
 
 use FastCGI::Connection;
 use FastCGI::Logger;

--- a/lib/FastCGI/Connection.pm6
+++ b/lib/FastCGI/Connection.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class FastCGI::Connection;
+unit class FastCGI::Connection;
 
 use PSGI;
 use FastCGI::Request;

--- a/lib/FastCGI/Constants.pm6
+++ b/lib/FastCGI/Constants.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-module FastCGI::Constants;
+unit module FastCGI::Constants;
 
 constant CRLF is export = "\x0D\x0A";
 constant ZERO is export = "\x00";

--- a/lib/FastCGI/Errors.pm6
+++ b/lib/FastCGI/Errors.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class FastCGI::Errors;
+unit class FastCGI::Errors;
 
 has @.messages;
 

--- a/lib/FastCGI/Logger.pm6
+++ b/lib/FastCGI/Logger.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class FastCGI::Logger;
+unit class FastCGI::Logger;
 
 ## TODO: pull this out of FastCGI and make it its own library.
 

--- a/lib/FastCGI/Protocol.pm6
+++ b/lib/FastCGI/Protocol.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-module FastCGI::Protocol;
+unit module FastCGI::Protocol;
 
 use FastCGI::Constants;
 use FastCGI::Protocol::Constants :ALL;

--- a/lib/FastCGI/Protocol/Constants.pm6
+++ b/lib/FastCGI/Protocol/Constants.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-module FastCGI::Protocol::Constants;
+unit module FastCGI::Protocol::Constants;
 
 #### Protocol constants.
 

--- a/lib/FastCGI/Request.pm6
+++ b/lib/FastCGI/Request.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class FastCGI::Request;
+unit class FastCGI::Request;
 
 use FastCGI::Constants;
 use FastCGI::Protocol;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.