### PR TITLE
A small change to mirror upstream changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Makefile
 blib
 *.swp
+**/.precomp

--- a/lib/FastCGI.pm6
+++ b/lib/FastCGI.pm6
@@ -26,10 +26,10 @@ has $.fancy-log = True;
 
 method connect (:$port=$.port, :$addr=$.addr)
 {
-  $!socket = IO::Socket::INET.new(
-    :localhost($addr), 
-    :localport($port), 
-    :listen(1)
+    $!socket = IO::Socket::INET.new(
+	:localhost($addr), 
+	:localport($port),
+	:listen
   );
 }
 


### PR DESCRIPTION
The `listen` parameter now seems to expect a boolean. 