### PR TITLE
Add `use experimental :pack`

### DIFF
--- a/lib/FastCGI/Protocol.pm6
+++ b/lib/FastCGI/Protocol.pm6
@@ -2,6 +2,7 @@ use v6;
 
 unit module FastCGI::Protocol;
 
+use experimental :pack;
 use FastCGI::Constants;
 use FastCGI::Protocol::Constants :ALL;
 #use FastCGI::Logger;


### PR DESCRIPTION
Protocol.pm6 is using experimental pack/unpack rakudo feature which
needs to be enabled with a pragma. Rakudo versions ≤ 2018.05 used to
give a run time error on first use, but starting with 2018.06 it will
be a compile time error. This means that the error will show up on
installation (e.g. `zef install FastCGI`), even though FastCGI
currently has no tests.